### PR TITLE
Revert to Dummy Data

### DIFF
--- a/DB/GADListViewController.m
+++ b/DB/GADListViewController.m
@@ -45,12 +45,19 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     
+    /* This method retrieved data from the test server, it will be left here
+     since the new API will hopefully be similar
     [GADQuery executeWithDict:_criteria Username:@"test1stu" Password:@"selfserv1" completionHandler:^void(NSArray<GADPerson *> * people,NSError *error){
         self.searchResult = people;
         dispatch_async(dispatch_get_main_queue(),^(void){
             [self.tableView reloadData];
         });
-    }];
+    }]; */
+    
+    self.searchResult = GADPerson.dummyPeople;
+    dispatch_async(dispatch_get_main_queue(),^(void){
+        [self.tableView reloadData];
+    });
 }
 
 - (void)didReceiveMemoryWarning {

--- a/DB/GADPerson.m
+++ b/DB/GADPerson.m
@@ -71,12 +71,13 @@
     person2.lastName=@"Osera";
     person2.email=@"oserapet@grinnell.edu";
     person2.address=@"3811 Science";
+    person2.box=@"SCIE";
     person2.phone=@"4010";
     person2.city=@"Grinnell";
     person2.state=@"IA";
     person2.zip=@"50112";
     person2.offCampusAddress=@[@"1804 3rd Ave"];
-    person2.title=@[@"Assistant Professor of Computer Science"];
+    person2.title=@[@"Assistant Professor of Computer Science", @"", @"", @"", @"", @"Computer Science"];
     person2.imgPath=[NSURL URLWithString:@"https://itwebapps.grinnell.edu/PcardImages/moved/84326.jpg"];
     
     person3.firstName=@"Anita";
@@ -85,6 +86,7 @@
     person3.major=@"Computer Science/Music";
     person3.email=@"dewittan17@grinnell.edu";
     person3.offCampusAddress=@[@"347 Drake Ave"];
+    person3.address=@"Hannibal Kershaw Hall 2349";
     person3.city=@"Bolingbrook";
     person3.state=@"IL";
     person3.zip=@"60490-3103";


### PR DESCRIPTION
The search page now always returns three dummy people -- one student, one SGA and one FacStaff. The old search method is left in as a comment, as the API built from the web-scraping will hopefully be similar. The data on line 80 of GADPerson.m has blank fields included as we cannot access the API anymore to know what data is used there. 